### PR TITLE
feat: ignore case for shell error messages and allow popup min/max width customization

### DIFF
--- a/autoload/gitblame.vim
+++ b/autoload/gitblame.vim
@@ -48,7 +48,7 @@ endfunction
 function! gitblame#commit_summary(file_dir, file_name, line)
     let git_blame = split(s:system('git -C "'.a:file_dir.'" --no-pager blame "'.a:file_name.'" -L '.a:line.',+1 --porcelain'), "\n")
     let l:shell_error = s:has_vimproc() ? vimproc#get_last_status() : v:shell_error
-    if l:shell_error && ( git_blame[0] =~# '^fatal: Not a git repository' || git_blame[0] =~# '^fatal: cannot stat path' )
+    if l:shell_error && ( git_blame[0] =~? '^fatal: Not a git repository' || git_blame[0] =~? '^fatal: cannot stat path' )
         return {'error': 'Not a git repository'}
     elseif l:shell_error
         return {'error': 'Unhandled error: '.git_blame[0]}
@@ -103,8 +103,8 @@ function! gitblame#vimpopup(gb)
 	  \ 'pos': 'botleft',
 	  \ 'line': 'cursor-1',
 	  \ 'col': 'cursor',
-	  \ 'minwidth': 20,
-	  \ 'maxwidth': 80,
+	  \ 'minwidth': get(g:, 'GBlamePopupMinWidth', 20),
+	  \ 'maxwidth': get(g:, 'GBlamePopupMaxWidth', 80),
 	  \ 'close': 'click',
 	  \ 'moved': 'WORD',
 	  \ 'drag:': 'TRUE',

--- a/syntax/gitblame.vim
+++ b/syntax/gitblame.vim
@@ -5,7 +5,8 @@ endif
 syn match gitmessengerHeader '\_^\%(Commit\|Date\|Author\|Committer\):' display
 syn match gitmessengerHash '\%(\<Commit: \)\@<=[[:xdigit:]]\+' display
 
-hi def link gitmessengerHeader	    Directory
+"hi def link gitmessengerHeader	    Directory
+hi def gitmessengerHeader	    ctermfg=darkblue
 hi def link gitmessengerHash        PreProc
 
 let b:current_syntax = 'gitblame'


### PR DESCRIPTION
Ignore case when comparing shell error messages from `git` CLI.
```shell
> git --version
git version 2.47.1

> git status
fatal: not a git repository (or any of the parent directories): .git
```
The "not" word is all lowercase.

While here also allow to customize popup min and max width